### PR TITLE
fix: split SSE line only on first separator in parseChunk

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -19,7 +19,10 @@ export function buildHeaders(accessToken?: string): Record<string, string> {
 
 export function parseChunk<T>(line: string): T | null {
   try {
-    const [name, value] = line.split(': ');
+    const idx = line.indexOf(': ');
+    if (idx === -1) return null;
+    const name = line.substring(0, idx);
+    const value = line.substring(idx + 2);
     if (name === 'data') {
       if (value === '[DONE]') {
         return null;


### PR DESCRIPTION
## Summary

- `parseChunk()` in `src/api/utils.ts` used `line.split(': ')` which splits on **all** occurrences of `: ` in the SSE data line
- When GigaChat streams content containing `: ` inside JSON (e.g. escaped quotes like `"\": [\""`), the JSON value gets truncated
- This causes `SyntaxError: Unterminated string in JSON` → `uncaughtException` → Node.js process crash

**Fix:** use `indexOf(': ')` + `substring` to split only on the first separator, preserving the full JSON payload.

## Reproduction

GigaChat sends an SSE chunk:
```
data: {"choices":[{"delta":{"content":"\": [\"","role":"assistant"},"index":0}]}
```

Before fix: `split(': ')` produces `["data", '{"choices"', '[{"delta"', ...]` → `value = '{"choices"'` → broken JSON

After fix: `indexOf(': ')` finds position 4 → `value = '{"choices":[{"delta":...'` → valid JSON

## Test plan

- [ ] Verify streaming responses with content containing `: ` parse correctly
- [ ] Verify `[DONE]` sentinel still handled
- [ ] Verify non-data SSE lines return null

🤖 Generated with [Claude Code](https://claude.com/claude-code)