### PR TITLE
отключен автопарсинг JSON у Axios

### DIFF
--- a/src/api/get_batch.ts
+++ b/src/api/get_batch.ts
@@ -18,6 +18,7 @@ function getRequestConfig({ fileId, accessToken }: GetBatchFileArgs): AxiosReque
     url: `/files/${fileId}/content`,
     headers,
     responseEncoding: 'binary',
+    transformResponse: [(data) => data],
   } as AxiosRequestConfig;
 }
 

--- a/src/api/get_batch.ts
+++ b/src/api/get_batch.ts
@@ -17,8 +17,7 @@ function getRequestConfig({ fileId, accessToken }: GetBatchFileArgs): AxiosReque
     method: 'GET',
     url: `/files/${fileId}/content`,
     headers,
-    responseEncoding: 'binary',
-    transformResponse: [(data) => data],
+    responseType: 'text',
   } as AxiosRequestConfig;
 }
 


### PR DESCRIPTION
При скачивании файла пакета запросов (/files/{{file_id}}/content), если запрос в пакете один, Axios автоматом парсит его как JSON, не смотря на то что content-type: 'application/octet-stream', из за этого вываливается в ошибку.
В конфиге аксиоса явно указал что принимаем. в первом коммите просто отключил автопарсинг но это привело к неверному прочтению кодировки, изменил во втором коммите.

