### PR TITLE
fix(stream_chat): buffer partial SSE lines across data chunks

### DIFF
--- a/src/api/stream_chat.ts
+++ b/src/api/stream_chat.ts
@@ -54,8 +54,30 @@ function checkResponse(response: AxiosResponse): void {
   }
 }
 
-function splitLines(data: string): string[] {
-  return data.split(/\r?\n/).filter((line) => line.trim() !== '');
+// Buffers a streaming UTF-8 text payload and yields complete lines. SSE
+// frames are delimited by '\n' (or '\r\n'), but TCP can deliver a single SSE
+// event across multiple `data` events — splitting mid-string inside a JSON
+// payload. A naive split-per-chunk feeds truncated lines to JSON.parse and
+// throws `SyntaxError: Unterminated string in JSON` synchronously inside the
+// 'data' handler, which surfaces as an uncaughtException and can crash the
+// host process.
+function createLineBuffer() {
+  let buffer = '';
+  return {
+    push(chunk: string): string[] {
+      buffer += chunk;
+      const parts = buffer.split(/\r?\n/);
+      // The last element is either '' (chunk ended on a newline) or a
+      // partial trailing line — keep it for the next chunk.
+      buffer = parts.pop() ?? '';
+      return parts.filter((line) => line.trim() !== '');
+    },
+    flush(): string[] {
+      const remainder = buffer;
+      buffer = '';
+      return remainder.trim() !== '' ? [remainder] : [];
+    },
+  };
 }
 
 export async function stream_chat(
@@ -120,35 +142,40 @@ export async function stream_chat_readable(
   const response = await client.request(config);
   checkResponse(response);
 
+  const lineBuffer = createLineBuffer();
+
+  const emitLines = (lines: string[]) => {
+    lines.forEach((line) => {
+      const chatChunk = parseChunk(line);
+      if (chatChunk) {
+        emitter.emit('chunk', buildXHeaders(response, chatChunk as ChatCompletionChunk)); // Отправка события с новым чанком
+      }
+    });
+  };
+
   if (isBrowser) {
+    const decoder = new TextDecoder();
     const reader = response.data.getReader();
     reader.read().then(function pump({ done, value }: { done: boolean; value: Uint8Array }) {
       if (done) {
+        // Flush trailing partial line — most servers end on a blank line, but
+        // be defensive in case the final SSE event is not newline-terminated.
+        emitLines(lineBuffer.flush());
         emitter.emit('end');
         return;
       } else {
-        const chunk = new TextDecoder().decode(value);
-        const lines = splitLines(chunk.toString());
-        lines.forEach((line) => {
-          const chatChunk = parseChunk(line);
-          if (chatChunk) {
-            emitter.emit('chunk', buildXHeaders(response, chatChunk as ChatCompletionChunk)); // Отправка события с новым чанком
-          }
-        });
+        // `stream: true` keeps multi-byte UTF-8 sequences split across chunks intact.
+        const chunk = decoder.decode(value, { stream: true });
+        emitLines(lineBuffer.push(chunk));
       }
       return reader.read().then(pump);
     });
   } else {
     response.data.on('data', (chunk: Buffer) => {
-      const lines = splitLines(chunk.toString());
-      lines.forEach((line) => {
-        const chatChunk = parseChunk(line);
-        if (chatChunk) {
-          emitter.emit('chunk', buildXHeaders(response, chatChunk as ChatCompletionChunk)); // Отправка события с новым чанком
-        }
-      });
+      emitLines(lineBuffer.push(chunk.toString()));
     });
     response.data.on('end', () => {
+      emitLines(lineBuffer.flush());
       emitter.emit('end'); // Отправка события завершения
     });
     response.data.on('error', (error: any) => {


### PR DESCRIPTION
## Problem

`splitLines` in `src/api/stream_chat.ts` operates on each incoming `response.data 'data'` chunk independently:

```ts
function splitLines(data: string): string[] {
  return data.split(/\r?\n/).filter((line) => line.trim() !== '');
}
```

It then hands every produced line to `parseChunk` → `JSON.parse`. There is **no buffer that carries the trailing partial line across chunks.**

TCP routinely fragments a single SSE event across multiple `data` events — the boundary can land anywhere, including in the middle of a JSON string. When that happens:

1. The first chunk ends with e.g. `data: {\"choices\":[{\"delta\":{\"content\":\"con` (no trailing `\n`).
2. `splitLines` returns this string as a complete line.
3. `parseChunk` calls `JSON.parse('{\"choices\":[{\"delta\":{\"content\":\"con')` → throws `SyntaxError: Unterminated string in JSON`.
4. The throw originates inside an `IncomingMessage` `'data'` listener — Node has no enclosing try/catch in user land, so it bubbles to `uncaughtException` and **terminates the host process**.

The browser branch (Fetch `ReadableStream.getReader()`) has the same issue, plus it decodes every `Uint8Array` with a fresh `TextDecoder()`, which **breaks multi-byte UTF-8 sequences** that straddle chunk boundaries — emitting U+FFFD instead of the intended character.

## Real-world crash

Captured on Node 22.22.0 running our agent-toolkit JS runtime in IFT (2026-05-12):

```
SyntaxError: Unterminated string in JSON at position 94 (line 1 column 95)
    at JSON.parse (<anonymous>)
    at parseChunk (gigachat/src/api/utils.ts:30:4)
    at <anonymous> (gigachat/src/api/stream_chat.ts:147:37)
    at Array.forEach (<anonymous>)
    at IncomingMessage.<anonymous> (gigachat/src/api/stream_chat.ts:146:13)
    at IncomingMessage.emit (node:events:519:28)
    at Readable.read (node:internal/streams/readable:782:10)
    at flow (node:internal/streams/readable:1283:53)
    at resume_ (node:internal/streams/readable:1262:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
```

→ `uncaughtException` → entire Node process terminated → every in-flight streaming session aborted. This caused user-visible errors of the form `peer closed connection without sending complete message body (incomplete chunked read)` in our HTTP parent process.

## Fix

Replace the stateless `splitLines` helper with a closure-based line buffer:

- **`push(chunk)`** appends the incoming text to an internal buffer, splits on `\r?\n`, and returns only complete lines. The trailing partial line is retained for the next push.
- **`flush()`** returns whatever's left in the buffer on stream end — defensive against final SSE events that aren't newline-terminated.

Both the Node (`response.data.on('data')`) and browser (`reader.read()`) branches now go through this buffer, and the browser branch uses `TextDecoder({ stream: true })` to preserve multi-byte UTF-8 across reads.

No public API change. No new dependencies.

## Test plan

- [x] `npx tsc --noEmit` is clean
- [ ] Manual: stream a long response that triggers TCP fragmentation; verify no `SyntaxError: Unterminated string` is thrown and `chunk` events still fire in order
- [ ] Manual: stream a response containing non-ASCII (Cyrillic/emoji) and verify no U+FFFD replacement characters appear
- [ ] Existing examples in `examples/source/stream.ts` and `stream_events.ts` continue to work